### PR TITLE
Redesign book detail/edit page to match Figma design

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -33,6 +33,7 @@ class Router {
         $this->routes['GET']['/books/{slug}/edit'] = 'BookController@edit';
         $this->routes['POST']['/books/{id}/update'] = 'BookController@update';
         $this->routes['POST']['/books/{id}/delete'] = 'BookController@delete';
+        $this->routes['POST']['/books/{id}/visibility'] = 'BookController@toggleVisibility';
         
         // Pages routes
         $this->routes['GET']['/books/{book_id}/pages/new'] = 'PageController@create';

--- a/app/views/partials/header.php
+++ b/app/views/partials/header.php
@@ -85,6 +85,23 @@
             display: inline;
         }
         
+        .back-button {
+            position: absolute;
+            left: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 40px;
+            height: 40px;
+            border-radius: 8px;
+            transition: background 0.2s ease;
+            color: #111111;
+        }
+        
+        .back-button:hover {
+            background: #F5F5F5;
+        }
+        
         /* Container override */
         .container {
             max-width: 1280px;
@@ -140,6 +157,13 @@
     <div class="page-container">
         <header class="header">
             <div class="header-content">
+                <?php if (isset($showBackButton) && $showBackButton): ?>
+                    <a href="/books" class="back-button">
+                        <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M12 19l-7-7 7-7" stroke-linecap="round" stroke-linejoin="round"/>
+                        </svg>
+                    </a>
+                <?php endif; ?>
                 <a href="/books" class="logo">strybk</a>
                 <form method="POST" action="/logout" class="logout-form">
                     <input type="hidden" name="_token" value="<?= $auth->csrfToken() ?>">


### PR DESCRIPTION
- Added back button to header for book pages
- Created two-column layout with book cover on left, chapters on right
- Implemented gallery and list view toggle for chapters
- Added privacy toggle button with public/private states
- Added public link display with copy functionality
- Added edit, share, and export action buttons
- Implemented drag-and-drop reordering for both views
- Added word count display for each chapter/page
- Styled to match Figma design with clean minimal aesthetic
- Made page thumbnails show preview of content in gallery view
- Added sticky positioning for book info section